### PR TITLE
generalise DOI URL reg-ex pattern

### DIFF
--- a/q.R
+++ b/q.R
@@ -85,8 +85,7 @@ data <- data %>%
 # test <- plyr::llply(paste0('doi:',"10.1093/acprof:oso/9780199560677.003.0006"), altmetrics, .progress = 'text')
 # Fails, although ought to be a correct DOI of a book. Anyway, ":" needs to be removed
 
-data$DOI <- gsub("https://dx.doi.org/|http://dx.doi.org/", "", data$DOI)
-data$DOI <- gsub("dx.doi.org/", "", data$DOI)
+data$DOI <- gsub("https?://(dx\\.)?doi.org/", "", data$DOI)
 data$DOI <- gsub("http://doi.ieeecomputersociety.org/", "", data$DOI)
 data$DOI <- gsub("http://|https://", "", data$DOI)
 data$DOI <- gsub("[aA]vailable.*", "", data$DOI)


### PR DESCRIPTION
Hello!

Because the DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) there may any combination of (non)-`https` and (non)-`dx` variants out there. This reg-ex should catch all four variants, with a bit less code than before.

Cheers :-)